### PR TITLE
Migrate to Laravel 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Javascript Routing for Laravel 4
+# Javascript Routing for Laravel 5
 
 This package allows you to access Laravel's routing from your Javascript.
 
@@ -20,7 +20,7 @@ Add the provider to **app.php**
 'DelormeJonathan\LaravelJsRouting\LaravelJsRoutingServiceProvider',
 ```
 
-Add the facade to **app.php**
+Add the facade to **app.php** to the **aliases** section
 
 ```
 'JSRouter' => 'DelormeJonathan\LaravelJsRouting\Facades\JSRouter',
@@ -29,7 +29,7 @@ Add the facade to **app.php**
 Publish assets to public folder
 
 ```
-php artisan asset:publish delormejonathan/laravel-js-routing
+php artisan vendor:publish --tag=public --force
 ```
 
 ## Usage
@@ -45,9 +45,9 @@ And import routes file dynamically in local and statically in production :
 
 ```html
 @if (App::environment() == 'production')
-	<script type="text/javascript" src="{{ asset('js/routes.js') }}"></script>
+	<script type="text/javascript" src="/js/routes.js"></script>
 @else
-	<script type="text/javascript">{{ JSRouter::generate() }}</script>
+	<script type="text/javascript">{!! JSRouter::generate() !!}</script>
 @endif
 ```
 

--- a/src/DelormeJonathan/LaravelJsRouting/Commands/Dump.php
+++ b/src/DelormeJonathan/LaravelJsRouting/Commands/Dump.php
@@ -21,7 +21,7 @@ class Dump extends Command {
 	protected function getArguments()
 	{
 		return array(
-			array('path', InputArgument::OPTIONAL, 'Path', 'public/js/routes.js'),
+			array('path', InputArgument::OPTIONAL, 'Path', public_path ('js/routes.js')),
 		);
 	}
 }

--- a/src/DelormeJonathan/LaravelJsRouting/JSRouter.php
+++ b/src/DelormeJonathan/LaravelJsRouting/JSRouter.php
@@ -22,6 +22,6 @@ class JSRouter
 		}
 
 
-		return View::make('LaravelJsRouting::script', array('routesByAction' => json_encode($routesByAction), 'routesByName' => json_encode($routesByName)));
+		return View::make('LaravelJsRouting::script', array('routesByAction' => $routesByAction, 'routesByName' => $routesByName));
 	}
 }

--- a/src/DelormeJonathan/LaravelJsRouting/LaravelJsRoutingServiceProvider.php
+++ b/src/DelormeJonathan/LaravelJsRouting/LaravelJsRoutingServiceProvider.php
@@ -19,7 +19,10 @@ class LaravelJsRoutingServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('delormejonathan/laravel-js-routing', 'LaravelJsRouting');
+		$this->publishes([
+			__DIR__.'/../../../public' => resource_path ('assets/vendor/laravel-js-routing'),
+		], 'public');
+		$this->loadViewsFrom(__DIR__.'/../../views', 'LaravelJsRouting');
 		$this->commands('dump');
 	}
 

--- a/src/views/script.blade.php
+++ b/src/views/script.blade.php
@@ -1,3 +1,3 @@
-JSRouter.routesByAction = {{ $routesByAction }}
+JSRouter.routesByAction = {!! json_encode ($routesByAction) !!}
 
-JSRouter.routesByName = {{ $routesByName }}
+JSRouter.routesByName = {!! json_encode ($routesByName) !!}


### PR DESCRIPTION
Enable the use of JSRouter with Laravel 5.

Service provider now describes the package correctly, enabling asset publishing and registering the view. README also has been updated to reflect these changes.
